### PR TITLE
Geometric altitude

### DIFF
--- a/adsb-mqtt/sbs1.py
+++ b/adsb-mqtt/sbs1.py
@@ -9,6 +9,7 @@ project by John Wiseman (github.com/wiseman/node-sbs1)
 from typing import *
 from datetime import datetime
 import logging
+import re
 try:
     import dateutil.parser
 except ImportError as e:
@@ -124,7 +125,8 @@ def __parseInt(array: List, index: int):
     """Parse int at given index in array
     Return int value or None if index is out of bounds or type casting failed"""
     try:
-        return int(array[index])
+        numbers = re.findall('[0-9]+', array[index])[0]        
+        return int(numbers)
     except ValueError as e:
         return None
     except TypeError as e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
       
   piaware:
-    image: mikenye/piaware:latest
+    build: ./piaware
     tty: true
     container_name: piaware
     restart: always

--- a/piaware/Dockerfile
+++ b/piaware/Dockerfile
@@ -1,0 +1,9 @@
+FROM mikenye/piaware:latest
+
+ADD run /etc/services.d/dump1090/
+
+EXPOSE 80/tcp 30003/tcp 30005/tcp 30105/tcp 30978/tcp 30979/tcp
+
+ENTRYPOINT [ "/init" ]
+
+HEALTHCHECK --start-period=7200s --interval=600s CMD /scripts/healthcheck.sh

--- a/piaware/run
+++ b/piaware/run
@@ -1,0 +1,51 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+set -eo pipefail
+
+mkdir -p /run/dump1090-fa
+
+DUMP1090_BIN="/usr/local/bin/dump1090"
+
+# Global settings
+DUMP1090_CMD=("--quiet")
+DUMP1090_CMD+=("--lat" "$LAT")
+DUMP1090_CMD+=("--lon" "$LONG")
+DUMP1090_CMD+=("--net")
+DUMP1090_CMD+=("--fix")
+DUMP1090_CMD+=("--gnss")
+DUMP1090_CMD+=("--json-location-accuracy" "2")
+DUMP1090_CMD+=("--write-json" "/run/dump1090-fa")
+DUMP1090_CMD+=("--net-bind-address" "0.0.0.0")
+
+# Handle "--modeac"
+if [[ "$ALLOW_MODEAC" == "yes" ]]; then
+        DUMP1090_CMD+=("--modeac")
+fi
+
+# If a BEASTHOST is specified
+if [[ -n "$BEASTHOST" ]]; then
+    DUMP1090_CMD+=("--net-only")
+
+# Default - rtlsdr mode
+else
+    DUMP1090_CMD+=("--device-type" "rtlsdr")
+
+    if [[ -n "$DUMP1090_DEVICE" ]]; then
+        DUMP1090_CMD+=("--device" "$DUMP1090_DEVICE")
+    fi
+
+    if [[ -n "$RTLSDR_PPM" ]]; then
+        DUMP1090_CMD+=("--ppm" "$RTLSDR_PPM")
+    fi
+
+    if [[ -n "$RTLSDR_GAIN" ]]; then
+        DUMP1090_CMD+=("--gain" "$RTLSDR_GAIN")
+    fi
+
+fi
+
+# shellcheck disable=SC2016
+"${DUMP1090_BIN}" "${DUMP1090_CMD[@]}" \
+  2>&1 | stdbuf -o0 awk '{print "[dump1090] " strftime("%Y/%m/%d %H:%M:%S", systime()) " " $0}'
+
+sleep 5


### PR DESCRIPTION
Update to use geometric altitude for all math operations vs. barometric altitude.  Geometric altitude is critical for azimuth/elevation calculations.

Reference issue: https://github.com/IQTLabs/SkyScan/issues/12