### PR TITLE
Set active = True after setting currentPlane to avoid race condition.

### DIFF
--- a/axis-ptz/camera.py
+++ b/axis-ptz/camera.py
@@ -313,9 +313,9 @@ def on_message(client, userdata, message):
         if "icao24" in update:
             if active is False:
                 logging.info("{}\t[Starting Capture]".format(update["icao24"]))
-            active = True
             logging.info("{}\t[IMAGE]\tBearing: {} \tElv: {} \tDist: {}".format(update["icao24"],int(update["bearing"]),int(update["elevation"]),int(update["distance"])))
             currentPlane = update
+            active = True
         else:
             if active is True:
                 logging.info("{}\t[Stopping Capture]".format(currentPlane["icao24"]))


### PR DESCRIPTION
Fixes a race condition in `axis-ptz/camera.py`.

The mqtt message handler was setting `active = True` before it set `currentPlane`, which meant that when the first message was received it would be possible for the camera thread to begin trying to process `currentPlane` when it was still `None`.

This probably isn't a race condition that would manifest often, but in my case I was sending the wrong JSON on the flight mqtt topic, which not only triggered the race but also was a bit extra confusing because the exception was being silently eaten (See PR #24).
