### PR TITLE
Add in the ability to inhibit photo saving

### DIFF
--- a/notebook-server/Config.ipynb
+++ b/notebook-server/Config.ipynb
@@ -295,7 +295,29 @@
     "json_data = json.dumps(data)\n",
     "client.publish(\"skyscan/config/json\",json_data)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inhibit Photos\n",
+    "Inhibits saving photos.  This is defaulted to False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.connect(broker)\n",
+    "data = {}\n",
+    "data['inhibitPhotos'] = True  # Update this Value\n",
+    "json_data = json.dumps(data)\n",
+    "client.publish(\"skyscan/config/json\",json_data)"
+   ]
   }
+
  ],
  "metadata": {
   "kernelspec": {


### PR DESCRIPTION
During testing, saving photos can fill up drives when not performing real testing.  This adds in a cell in the Jupyter Notebook to inhibit saving photographs.

Additionally, this allows optical tracking to go up to 10Hz vs. 1Hz.