### PR TITLE
Include flight message age in aircraft lead time

### DIFF
--- a/axis-ptz/camera.py
+++ b/axis-ptz/camera.py
@@ -401,14 +401,19 @@ def calculateCameraPositionB(
     # Assign position and velocity of the aircraft
     a_varphi = currentPlane["lat"]  # [deg]
     a_lambda = currentPlane["lon"]  # [deg]
-    # currentPlane["latLonTime"]
+    a_time = currentPlane["latLonTime"]  # [s]
     a_h = currentPlane["altitude"]  # [m]
-    # currentPlane["altitudeTime"]
+    # currentPlane["altitudeTime"]  # Expect altitudeTime to equal latLonTime
     a_track = currentPlane["track"]  # [deg]
     a_ground_speed = currentPlane["groundSpeed"]  # [m/s]
     a_vertical_rate = currentPlane["verticalRate"]  # [m/s]
     # currentPlane["icao24"]
     # currentPlane["type"]
+
+    # Compute lead time accounting for age of message, and specified
+    # lead time
+    a_datetime = utils.convert_time(a_time)
+    a_lead = (datetime.utcnow() - a_datetime).total_seconds() + camera_lead  # [s]
 
     # Assign position of the tripod
     t_varphi = camera_latitude  # [deg]
@@ -431,7 +436,7 @@ def calculateCameraPositionB(
             a_vertical_rate,
         ]
     )
-    r_ENz_a_1_t = r_ENz_a_0_t + v_ENz_a_0_t * camera_lead
+    r_ENz_a_1_t = r_ENz_a_0_t + v_ENz_a_0_t * a_lead
 
     # Compute position, at time one, and velocity, at time zero, in
     # the XYZ coordinate system of the aircraft relative to the tripod

--- a/axis-ptz/utils.py
+++ b/axis-ptz/utils.py
@@ -264,15 +264,11 @@ def calc_travel_3d(current_plane, lead_s: float):
     heading = current_plane["track"]
     climb_rate = current_plane["verticalRate"]
 
-    # TODO: Restore
-    # lat_lon_age = datetime.utcnow() - lat_lon_time
-    # lat_lon_age_s = lat_lon_age.total_seconds() + lead_s
-    lat_lon_age_s = lead_s
+    lat_lon_age = datetime.utcnow() - lat_lon_time
+    lat_lon_age_s = lat_lon_age.total_seconds() + lead_s
 
-    # TODO: Restore
-    # alt_age = datetime.utcnow() - altitude_time
-    # alt_age_s = alt_age.total_seconds() + lead_s
-    alt_age_s = lead_s
+    alt_age = datetime.utcnow() - altitude_time
+    alt_age_s = alt_age.total_seconds() + lead_s
 
     R = float(6371)  # Radius of the Earth in km
     brng = math.radians(heading)  # Bearing is 90 degrees converted to radians.

--- a/axis-ptz/utils.py
+++ b/axis-ptz/utils.py
@@ -237,7 +237,7 @@ def convert_time(inp_date_time):
     return out_date_time
 
 
-def calc_travel_3d(current_plane, lead_s: float):
+def calc_travel_3d(current_plane, lead_s: float, include_age=True):
     """Extrapolate the 3D position of the aircraft
 
     Arguments:
@@ -264,11 +264,16 @@ def calc_travel_3d(current_plane, lead_s: float):
     heading = current_plane["track"]
     climb_rate = current_plane["verticalRate"]
 
-    lat_lon_age = datetime.utcnow() - lat_lon_time
-    lat_lon_age_s = lat_lon_age.total_seconds() + lead_s
+    if include_age:
+        lat_lon_age = datetime.utcnow() - lat_lon_time
+        lat_lon_age_s = lat_lon_age.total_seconds() + lead_s
 
-    alt_age = datetime.utcnow() - altitude_time
-    alt_age_s = alt_age.total_seconds() + lead_s
+        alt_age = datetime.utcnow() - altitude_time
+        alt_age_s = alt_age.total_seconds() + lead_s
+    
+    else:
+        lat_lon_age_s = lead_s
+        alt_age_s = lead_s
 
     R = float(6371)  # Radius of the Earth in km
     brng = math.radians(heading)  # Bearing is 90 degrees converted to radians.
@@ -294,8 +299,8 @@ def calc_travel_3d(current_plane, lead_s: float):
     return (lat2, lon2, alt2)
 
 
-def angular_velocity(currentPlane, camera_latitude, camera_longitude, camera_altitude):
-    (lat, lon, alt) = calc_travel_3d(currentPlane, 0)
+def angular_velocity(currentPlane, camera_latitude, camera_longitude, camera_altitude, include_age=True):
+    (lat, lon, alt) = calc_travel_3d(currentPlane, 0, include_age=include_age)
     distance2d = coordinate_distance(camera_latitude, camera_longitude, lat, lon)
     bearing1 = bearingFromCoordinate(
         cameraPosition=[camera_latitude, camera_longitude],
@@ -306,7 +311,7 @@ def angular_velocity(currentPlane, camera_latitude, camera_longitude, camera_alt
         distance2d, cameraAltitude=camera_altitude, airplaneAltitude=alt
     )
 
-    (lat, lon, alt) = calc_travel_3d(currentPlane, 1)
+    (lat, lon, alt) = calc_travel_3d(currentPlane, 1, include_age=include_age)
     distance2d = coordinate_distance(camera_latitude, camera_longitude, lat, lon)
     bearing2 = bearingFromCoordinate(
         cameraPosition=[camera_latitude, camera_longitude],


### PR DESCRIPTION
Note that for testing an environment variable INCLUDE_AGE must be set to "False". By default, age of the flight message is included in computing the aircraft lead time.